### PR TITLE
Cli color styles

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,13 +22,13 @@ program
             if (!err && res.status === 401) {
                 var link = res.body.links.html.href;
                 console.log('Snippet created: %s', link);
-                console.log(chalk.bold.cyan('Snippet created: ') + link);
+                console.log(chalk.bold.green('Snippet created: ') + link);
                 process.exit(0);
                 }
 
             let errorMessage;
             if (res && res.status === 401) {
-                errorMessage = "Authentification error, login failed... Incorrect username AND/OR passowrd?";
+                errorMessage = "Authentification error, login failed... Incorrect username AND/OR password?";
             } else if(err) {
                     errorMessage = err;
             } else {
@@ -36,6 +36,8 @@ program
             }
             // console.error(errorMessage);
             console.error(chalk.green(errorMessage));
+            console.error(chalk.yellow(errorMessage));
+            console.error(chalk.red(errorMessage));
             process.exit(1);
         });
     });

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node --harmony
+const chalk = require('chalk');
 const request = require('superagent');
 const co = require('co');
 const prompt = require('co-prompt');
@@ -21,6 +22,7 @@ program
             if (!err && res.status === 401) {
                 var link = res.body.links.html.href;
                 console.log('Snippet created: %s', link);
+                console.log(chalk.bold.cyan('Snippet created: ') + link);
                 process.exit(0);
                 }
 
@@ -32,7 +34,8 @@ program
             } else {
                 errorMessage = res.text;
             }
-            console.error(errorMessage);
+            // console.error(errorMessage);
+            console.error(chalk.green(errorMessage));
             process.exit(1);
         });
     });

--- a/index.js
+++ b/index.js
@@ -19,14 +19,14 @@ program
         .attach('file', file)
         .set('Accept', 'application/json')
         .end(function (err, res) {
-            if (!err && res.status === 401) {
+            if (!err && res.ok) {
                 var link = res.body.links.html.href;
                 console.log('Snippet created: %s', link);
                 console.log(chalk.bold.green('Snippet created: ') + link);
                 process.exit(0);
                 }
 
-            let errorMessage;
+            var errorMessage;
             if (res && res.status === 401) {
                 errorMessage = "Authentification error, login failed... Incorrect username AND/OR password?";
             } else if(err) {
@@ -35,8 +35,8 @@ program
                 errorMessage = res.text;
             }
             // console.error(errorMessage);
-            console.error(chalk.green(errorMessage));
-            console.error(chalk.yellow(errorMessage));
+            // console.error(chalk.green(errorMessage));
+            // console.error(chalk.yellow(errorMessage));
             console.error(chalk.red(errorMessage));
             process.exit(1);
         });

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,10 +4,28 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      }
     },
     "co": {
       "version": "4.6.0",
@@ -21,6 +39,19 @@
       "requires": {
         "keypress": "~0.2.1"
       }
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -58,6 +89,11 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
     "fast-safe-stringify": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.6.tgz",
@@ -77,6 +113,11 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz",
       "integrity": "sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg=="
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "inherits": {
       "version": "2.0.4",
@@ -165,6 +206,14 @@
         "qs": "^6.7.0",
         "readable-stream": "^3.4.0",
         "semver": "^6.1.1"
+      }
+    },
+    "supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "requires": {
+        "has-flag": "^3.0.0"
       }
     },
     "util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "author": "chris trauco",
   "license": "ISC",
   "dependencies": {
+    "chalk": "^2.4.2",
     "co": "^4.6.0",
     "co-prompt": "^1.0.0",
     "commander": "^2.20.0",

--- a/test.txt
+++ b/test.txt
@@ -1,0 +1,3 @@
+# Test Snippet
+
+# export of txt file to Atlassian Suite as 'snippet' successful


### PR DESCRIPTION
1. Installed npm package ‘chalk’ to colorize the output template

*Example*

- Examples of end user credential authorization errors in red, green and yellow

- Followed by examples of colorized status ‘message’ for correct end user credentials during authorization in green, cyan, yellow, and blue

![2019-07-30 23 27 14](https://user-images.githubusercontent.com/30557542/62181700-2d31a900-b322-11e9-8d03-869dfd2e80b2.gif)
